### PR TITLE
feat: Increase btc min balance to 0.0004

### DIFF
--- a/src/migrate/data/assets.json
+++ b/src/migrate/data/assets.json
@@ -2,7 +2,7 @@
   {
     "code": "BTC",
     "actualBalance": 0,
-    "min": 80000,
+    "min": 40000,
     "max": 45000000,
     "minConf": 1
   },

--- a/src/migrate/data/markets.json
+++ b/src/migrate/data/markets.json
@@ -7,7 +7,7 @@
     "orderExpiresIn": 7200000,
     "status": "ACTIVE",
     "max": 28163916,
-    "min": 80000
+    "min": 40000
   },
   {
     "from": "ETH",


### PR DESCRIPTION
Issue:

https://linear.app/liquality/issue/LIQ-113/for-btc-min-should-be-00004-max-should-be-their-available-balance

![image](https://user-images.githubusercontent.com/32274987/137093939-00176f94-1345-4210-afa6-e275a51f394d.png)
