### PR TITLE
fix: Check CAL version based on range rather than locking on minor ve…

### DIFF
--- a/src/middlewares/ensureUserAgentCompatible.js
+++ b/src/middlewares/ensureUserAgentCompatible.js
@@ -1,7 +1,6 @@
 const semver = require('semver')
-const pkg = require('../../package.json')
 
-const AGENT_CAL_VERSION = pkg.dependencies['@liquality/client'].replace('^', '').replace('~', '')
+const CAL_VERSION_CHECK = '>=1.4.3'
 const USER_AGENT_REGEX = /Wallet (\d.*?\.\d.*?\.\d.*?) \(CAL (\d.*?\.\d.*?\.\d.*?)\)/
 
 module.exports = (incompatibleResponse) => (req, res, next) => {
@@ -10,7 +9,7 @@ module.exports = (incompatibleResponse) => (req, res, next) => {
     const matches = USER_AGENT_REGEX.exec(userAgent)
     if (matches) {
       const userCALVersion = matches[2]
-      const isUserAgentCompatible = ['patch', null].includes(semver.diff(userCALVersion, AGENT_CAL_VERSION))
+      const isUserAgentCompatible = semver.satisfies(userCALVersion, CAL_VERSION_CHECK)
       if (!isUserAgentCompatible) return res.json(incompatibleResponse)
     }
   }


### PR DESCRIPTION
…rsion

Instead of locking to minor version, allow a range to be specified for acceptable CAL version.

**Background:** 

We added this check so that contract upgrades on CAL would mean users are prevented from swapping until they have the correct version.

In reality, only once since adding this check did the contracts upgrade. But it has introduced 2 issues for us:

- Anytime minor update on CAL, we have to sync releases of wallet and agent (tricky) - even though it's not required
- Older version of wallet are prevented from swapping even though it's perfectly fine to do so

Instead, we can update the version check whenever we are aware of a contract change