### PR TITLE
RegexMatch fix mongo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test/docker/config/*
 !test/docker/config/bitcoin.conf
 docker-commands.md
 .DS_Store
+query.txt

--- a/src/api/routes/dash.js
+++ b/src/api/routes/dash.js
@@ -265,7 +265,6 @@ router.get(
     })
     let allMarkets = (await Market.find({}, 'from to').lean().exec()).map((market) => `${market.from}-${market.to}`)
 
-    debug('all the markets', allMarkets)
     const groupSize = 10
     let result = []
     const marketGroups = allMarkets
@@ -277,7 +276,6 @@ router.get(
       })
 
     marketGroups.forEach(async (markets) => {
-      debug('Markets ', markets)
       const $group = markets.reduce((acc, market) => {
         acc[`market:${market}:sum:fromAmountUsd`] = {
           $sum: { $cond: [{ $eq: ['$market', market] }, '$fromAmountUsd', 0] }
@@ -329,7 +327,6 @@ router.get(
           }
         }
       ]).exec()
-      debug('Makerts response', JSON.stringify(marketResult))
       result.push(marketResult)
     })
 
@@ -347,7 +344,6 @@ router.get(
     })
 
     result = finalResults
-
     const stats = result.map((json) => {
       json.date = json._id
       delete json._id
@@ -369,7 +365,7 @@ router.get(
 
       return json
     })
-
+    debug('result=>', stats)
     const emptyDataPoint = {
       'wallet:sum:fromAmountUsd': 0,
       'wallet:sum:toAmountUsd': 0,

--- a/src/api/routes/dash.js
+++ b/src/api/routes/dash.js
@@ -304,6 +304,8 @@ router.get(
       }
     ]).exec()
 
+    debug('result data ', JSON.stringify(result))
+
     const stats = result.map((json) => {
       json.date = json._id
       delete json._id

--- a/src/api/routes/dash.js
+++ b/src/api/routes/dash.js
@@ -247,7 +247,7 @@ router.get(
     })
     let markets = (await Market.find({}, 'from to').lean().exec()).map((market) => `${market.from}-${market.to}`)
 
-    markets = markets.slice(0, 25)
+    markets = markets.slice(0, 15)
     debug('markets ', markets)
 
     const $group = markets.reduce((acc, market) => {

--- a/src/api/routes/dash.js
+++ b/src/api/routes/dash.js
@@ -247,7 +247,7 @@ router.get(
     })
     let markets = (await Market.find({}, 'from to').lean().exec()).map((market) => `${market.from}-${market.to}`)
 
-    markets = markets.slice(0, 15)
+    markets = markets.slice(0, 10)
     debug('markets ', markets)
 
     const $group = markets.reduce((acc, market) => {

--- a/src/api/routes/dash.js
+++ b/src/api/routes/dash.js
@@ -282,17 +282,17 @@ router.get(
           ...$group,
           'wallet:sum:fromAmountUsd': {
             $sum: {
-              $cond: [{ $regexMatch: { input: '$userAgent', regex: /^Wallet/i } }, '$fromAmountUsd', 0]
+              $cond: [{ $or: { input: '$userAgent', regex: /^Wallet/i } }, '$fromAmountUsd', 0]
             }
           },
           'wallet:sum:toAmountUsd': {
             $sum: {
-              $cond: [{ $regexMatch: { input: '$userAgent', regex: /^Wallet/i } }, '$toAmountUsd', 0]
+              $cond: [{ $or: { input: '$userAgent', regex: /^Wallet/i } }, '$toAmountUsd', 0]
             }
           },
           'wallet:count': {
             $sum: {
-              $cond: [{ $regexMatch: { input: '$userAgent', regex: /^Wallet/i } }, 1, 0]
+              $cond: [{ $or: { input: '$userAgent', regex: /^Wallet/i } }, 1, 0]
             }
           },
           'sum:totalAgentFeeUsd': { $sum: '$totalAgentFeeUsd' },

--- a/src/api/routes/dash.js
+++ b/src/api/routes/dash.js
@@ -275,7 +275,7 @@ router.get(
         return e
       })
 
-    marketGroups.forEach(async (markets) => {
+    for (const markets of marketGroups) {
       const $group = markets.reduce((acc, market) => {
         acc[`market:${market}:sum:fromAmountUsd`] = {
           $sum: { $cond: [{ $eq: ['$market', market] }, '$fromAmountUsd', 0] }
@@ -327,9 +327,8 @@ router.get(
           }
         }
       ]).exec()
-
       result.push(marketResult)
-    })
+    }
 
     //flatten and group by date
     let flattenResult = result.flat(1).reduce((r, ele) => {

--- a/src/api/routes/dash.js
+++ b/src/api/routes/dash.js
@@ -344,6 +344,7 @@ router.get(
     })
 
     result = finalResults
+    debug('result=>', result)
     const stats = result.map((json) => {
       json.date = json._id
       delete json._id

--- a/src/api/routes/dash.js
+++ b/src/api/routes/dash.js
@@ -327,6 +327,8 @@ router.get(
           }
         }
       ]).exec()
+
+      debug('market result =>', marketResult)
       result.push(marketResult)
     })
 
@@ -337,7 +339,6 @@ router.get(
       return r
     }, Object.create(null))
 
-    debug('result=>', result)
     //merge all with sum
     let finalResults = []
     Object.keys(result).forEach((key) => {

--- a/src/api/routes/dash.js
+++ b/src/api/routes/dash.js
@@ -328,21 +328,21 @@ router.get(
         }
       ]).exec()
 
-      debug('market result =>', marketResult)
       result.push(marketResult)
     })
 
     //flatten and group by date
-    result = result.flat(1).reduce((r, ele) => {
+    let flattenResult = result.flat(1).reduce((r, ele) => {
       r[ele._id] = r[ele._id] || []
       r[ele._id].push(ele)
       return r
     }, Object.create(null))
 
+    debug('market result =>', flattenResult)
     //merge all with sum
     let finalResults = []
-    Object.keys(result).forEach((key) => {
-      finalResults.push(mergeJSON(result[key]))
+    Object.keys(flattenResult).forEach((key) => {
+      finalResults.push(mergeJSON(flattenResult[key]))
     })
 
     result = finalResults

--- a/src/api/routes/dash.js
+++ b/src/api/routes/dash.js
@@ -1,7 +1,7 @@
 const asyncHandler = require('express-async-handler')
 const router = require('express').Router()
 const { fromUnixTime, differenceInDays, parseISO, compareAsc, eachDayOfInterval, format } = require('date-fns')
-
+const debug = require('debug')('liquality:agent:dash')
 const Market = require('../../models/Market')
 const Order = require('../../models/Order')
 const MarketHistory = require('../../models/MarketHistory')
@@ -240,11 +240,15 @@ router.get(
 router.get(
   '/stats',
   asyncHandler(async (req, res) => {
+    debug('req query ', req.query)
     const query = createQuery({
       ...req.query,
       status: ['AGENT_CLAIMED']
     })
-    const markets = (await Market.find({}, 'from to').lean().exec()).map((market) => `${market.from}-${market.to}`)
+    let markets = (await Market.find({}, 'from to').lean().exec()).map((market) => `${market.from}-${market.to}`)
+
+    markets = markets.slice(0, 25)
+    debug('markets ', markets)
 
     const $group = markets.reduce((acc, market) => {
       acc[`market:${market}:sum:fromAmountUsd`] = {
@@ -259,6 +263,8 @@ router.get(
 
       return acc
     }, {})
+
+    debug('groups ', JSON.stringify($group))
 
     const result = await Order.aggregate([
       {

--- a/src/api/routes/dash.js
+++ b/src/api/routes/dash.js
@@ -337,6 +337,7 @@ router.get(
       return r
     }, Object.create(null))
 
+    debug('result=>', result)
     //merge all with sum
     let finalResults = []
     Object.keys(result).forEach((key) => {
@@ -344,7 +345,7 @@ router.get(
     })
 
     result = finalResults
-    debug('result=>', result)
+
     const stats = result.map((json) => {
       json.date = json._id
       delete json._id


### PR DESCRIPTION
1. RegexMatch is not supported by DocumentDB
2. There are too many fields in the query

Above are addressed in the PR 